### PR TITLE
`debounceTimeout` default fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This option when set will issue a callback on the first event.
 
 #### options.debounceTimeout
 Type: `Number`
-Default: `1000`
+Default: `100`
 
 The number of milliseconds to debounce.
 


### PR DESCRIPTION
The readme states 1000 but it's actually 100.
